### PR TITLE
Make test deps optional

### DIFF
--- a/opam-nix.hs
+++ b/opam-nix.hs
@@ -9,7 +9,7 @@ import Data.Functor.Identity (Identity ())
 import System.IO
 import Data.Maybe (catMaybes, isNothing, maybeToList)
 import Control.Monad (void)
-import Data.List (stripPrefix, intersperse, nub, isSuffixOf, isPrefixOf)
+import Data.List (stripPrefix, intercalate, intersperse, nub, isSuffixOf, isPrefixOf)
 
 data OPAM
   = OPAM
@@ -43,13 +43,13 @@ opam2nix OPAM {..} =
     installPhase' = case installPhase of
       Just c -> "mkdir -p $OCAMLFIND_DESTDIR\n" <> preparephase c
       Nothing -> "opaline -prefix $out -libdir $OCAMLFIND_DESTDIR"
-    inputs = buildInputs' ++ checkInputs' ++ nativeBuildInputs'
+    inputs = buildInputs' ++ ((<>" ? null") <$> checkInputs') ++ nativeBuildInputs'
     deps = mconcat $ intersperse ", " $ normalize $ inputs
     sepspace = mconcat . intersperse " " . normalize
     quote s = "\""<>s<>"\""
     preparephase = mconcat . intersperse " "  . mconcat . intersperse ["\n"] . (fmap . fmap) quote
   in
-    "{ stdenv, fetchurl, lib, " <>deps<> ", extraArgs ? { } }@args:\n"
+    "{ stdenv, fetchurl, lib, " <>deps<> ", doCheck ? true, extraArgs ? { } }@args:\n"
   <>"stdenv.mkDerivation (let self = with self; with extraArgs; {\n"
   <>foldMap (\name' -> "  pname = \""<>name'<>"\";\n") name
   <>foldMap (\version' -> "  version = \""<>version'<>"\";\n") version

--- a/opam-nix.hs
+++ b/opam-nix.hs
@@ -4,12 +4,15 @@
 
 {-# LANGUAGE FlexibleContexts, LambdaCase, RecordWildCards #-}
 
-import Text.Parsec
-import Data.Functor.Identity (Identity ())
-import System.IO
-import Data.Maybe (catMaybes, isNothing, maybeToList)
 import Control.Monad (void)
+import Data.Bool (bool)
+import Data.Functor.Identity (Identity ())
 import Data.List (stripPrefix, intercalate, intersperse, nub, isSuffixOf, isPrefixOf)
+import Data.Maybe (catMaybes, isNothing, maybeToList)
+import Data.Set (Set, difference, fromList, toList, union)
+import qualified Data.Set as Set (map)
+import System.IO
+import Text.Parsec
 
 data OPAM
   = OPAM
@@ -23,6 +26,30 @@ data OPAM
   , installPhase :: Maybe [[String]]
   , source :: Maybe (String, [Hash])
   } deriving Show
+
+data PackageInputs = PackageInputs
+  { piNativeBuildInputs :: Set String
+  , piBuildInputs :: Set String
+  , piCheckInputs :: Set String
+  }
+
+printInputs :: PackageInputs -> String
+printInputs PackageInputs{..} =
+  "{ stdenv, fetchurl, lib"
+  <> pPrintInputs (union piNativeBuildInputs piBuildInputs)
+  <> pPrintInputs (Set.map (<>" ? null") onlyCheckInputs)
+  <> ", extraArgs ? { } }@args:\n"
+  where
+    -- to avoide duplicates
+    onlyCheckInputs = (piCheckInputs `difference` piBuildInputs) `difference` piNativeBuildInputs
+    sepcoma :: [String] -> String
+    sepcoma = intercalate ", "
+    pPrintInputs :: Set String -> String
+    pPrintInputs inputs =
+      bool "" (", " <> sepcoma (map normalizeInput $ toList inputs)) $ not $ null inputs
+    normalizeInput input
+      | "base-" `isPrefixOf` input = "base"
+      | otherwise = input
 
 -- Turn a description into a nix file
 opam2nix :: OPAM -> String
@@ -43,13 +70,16 @@ opam2nix OPAM {..} =
     installPhase' = case installPhase of
       Just c -> "mkdir -p $OCAMLFIND_DESTDIR\n" <> preparephase c
       Nothing -> "opaline -prefix $out -libdir $OCAMLFIND_DESTDIR"
-    inputs = buildInputs' ++ ((<>" ? null") <$> checkInputs') ++ nativeBuildInputs'
-    deps = mconcat $ intersperse ", " $ normalize $ inputs
     sepspace = mconcat . intersperse " " . normalize
     quote s = "\""<>s<>"\""
     preparephase = mconcat . intersperse " "  . mconcat . intersperse ["\n"] . (fmap . fmap) quote
+    packageInputs = PackageInputs
+      { piNativeBuildInputs = fromList nativeBuildInputs'
+      , piBuildInputs = fromList buildInputs'
+      , piCheckInputs = fromList checkInputs'
+      }
   in
-    "{ stdenv, fetchurl, lib, " <>deps<> ", doCheck ? true, extraArgs ? { } }@args:\n"
+    printInputs packageInputs
   <>"stdenv.mkDerivation (let self = with self; with extraArgs; {\n"
   <>foldMap (\name' -> "  pname = \""<>name'<>"\";\n") name
   <>foldMap (\version' -> "  version = \""<>version'<>"\";\n") version
@@ -229,8 +259,8 @@ stringParser = mconcat <$> between (char '"') (char '"') (many $ ((pure <$> none
 
 -- Expression is either a string or a variable
 expParser :: ParsecT String u Identity Exp
-expParser = try (Str <$> stringParser)
-        <|> Var <$> many1 (noneOf " \n\"{}[]")
+expParser =
+  (try (Str <$> stringParser) <|> Var <$> many1 (noneOf " \n\"{}[]")) <* additionalInfoParser
 
 -- "Additional Info" is additional information about a package or command, "{like-this}"
 additionalInfoParser :: ParsecT String u Identity [String]


### PR DESCRIPTION
Problem: Sometimes opam packages have invalid non-existing
test dependencies ¯\_(ツ)_/¯. This causes nix to gracefully
fail due to a function call without required arguments.

Solution: Make test deps optional, also add asserts for 'doCheck'.