### PR TITLE
Always add ppx_inline_test to buildInputs

### DIFF
--- a/opam-nix.hs
+++ b/opam-nix.hs
@@ -129,8 +129,11 @@ evaluateField o@OPAM {..} = \case
   Version s -> o { version = update version s }
   Depends s -> o {
     buildInputs = update buildInputs $
-      fmap identifier $ filter (\(Package _ info) ->
-                                  not $ ("with-test" `elem` info || "build" `elem` info)) s,
+      fmap identifier $ filter (\(Package name info) ->
+                                  -- ppx_inline_test is used for inlining tests to the source code
+                                  -- and usually needed during the build.
+                                  name == "ppx_inline_test" || not ("with-test" `elem` info || "build" `elem` info)
+                               ) s,
     nativeBuildInputs = update nativeBuildInputs $
       fmap identifier $ filter (\(Package _ info) -> "build" `elem` info) s,
     checkInputs = update checkInputs $


### PR DESCRIPTION
Problem: ppx_inline_test is a library which can be used for inlining
tests into the source code and thus it's actually needed during the
build.

Solution: Add it to the buildInputs even if it has '{with-test}'
condition.